### PR TITLE
update sparsification flow diagrams to have backgrounds and padding

### DIFF
--- a/docs/source/sparsification/flow-deployent-model_baseline-engine_baseline.svg
+++ b/docs/source/sparsification/flow-deployent-model_baseline-engine_baseline.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployent-model_baseline-engine_baseline</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployent-model_baseline-engine_baseline" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,148.5 L250,148.912821 C279.812758,148.912821 306.233451,168.113571 315.439086,196.469467 L336.560914,261.530533 C345.766549,289.886429 372.187242,309.087179 402,309.087179 L402,309.087179 L402,309.087179 L426.5,309.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,373 L250,373 L258.768944,373 C284.854277,373 309.550781,361.245192 326,341 C342.449219,320.754808 367.145723,309 393.231056,309 L402,309 L402,309 L426,309" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,308.911504 L743,309 L786.265028,309 C791.84356,309 797.41231,308.533201 802.912994,307.604489 L845.087006,300.484007 C850.58769,299.555294 856.15644,299.088496 861.734972,299.088496 L903.1025,299.088496 L903.1025,299.088496 L923.5,299" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,149 L246,149.530035 L701.847819,149.07243 C744.92779,149.029184 783.193445,176.580334 796.816534,217.449603 L801.207592,230.622777 C814.818997,271.456991 853.032881,299 896.075922,299 L906,299 L906,299 L923.5,298.469965" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,196.5 L298,196.912821 C327.812758,196.912821 354.233451,216.113571 363.439086,244.469467 L384.560914,309.530533 C393.766549,337.886429 420.187242,357.087179 450,357.087179 L450,357.087179 L450,357.087179 L474.5,357.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,421 L298,421 L306.768944,421 C332.854277,421 357.550781,409.245192 374,389 C390.449219,368.754808 415.145723,357 441.231056,357 L450,357 L450,357 L474,357" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,356.911504 L791,357 L834.265028,357 C839.84356,357 845.41231,356.533201 850.912994,355.604489 L893.087006,348.484007 C898.58769,347.555294 904.15644,347.088496 909.734972,347.088496 L951.1025,347.088496 L951.1025,347.088496 L971.5,347" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,197 L294,197.530035 L749.847819,197.07243 C792.92779,197.029184 831.193445,224.580334 844.816534,265.449603 L849.207592,278.622777 C862.818997,319.456991 901.032881,347 944.075922,347 L954,347 L954,347 L971.5,346.469965" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-deployment-model_baseline-engine_deepsparse.svg
+++ b/docs/source/sparsification/flow-deployment-model_baseline-engine_deepsparse.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployment-model_baseline-engine_deepsparse</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployment-model_baseline-engine_deepsparse" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 42.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 263.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 200.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 176.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,148.5 L250,148.907692 C279.834814,148.907692 306.297368,168.06436 315.614455,196.407048 L336.385545,259.592952 C345.702632,287.93564 372.165186,307.092308 402,307.092308 L402,307.092308 L402,307.092308 L426.5,307.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,374 L250,374 L257.594222,374 C284.346842,374 309.597327,361.634213 326,340.5 C342.402673,319.365787 367.653158,307 394.405778,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.336283 L743,308 L747.286757,308 C777.19766,308 805.462289,294.305575 824,270.831858 C842.537711,247.358141 870.80234,233.663717 900.713243,233.663717 L903.1025,233.663717 L903.1025,233.663717 L923.5,233" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,149 L246,149.29682 L725.12261,149.027477 C755.42727,149.010441 783.499653,164.959417 799,191 C814.501672,217.04281 842.570141,233 872.877398,233 L906,233 L906,233 L923.5,232.70318" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,190.5 L298,190.907692 C327.834814,190.907692 354.297368,210.06436 363.614455,238.407048 L384.385545,301.592952 C393.702632,329.93564 420.165186,349.092308 450,349.092308 L450,349.092308 L450,349.092308 L474.5,349.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,416 L298,416 L305.594222,416 C332.346842,416 357.597327,403.634213 374,382.5 C390.402673,361.365787 415.653158,349 442.405778,349 L450,349 L450,349 L474,349" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,349.336283 L791,350 L795.286757,350 C825.19766,350 853.462289,336.305575 872,312.831858 C890.537711,289.358141 918.80234,275.663717 948.713243,275.663717 L951.1025,275.663717 L951.1025,275.663717 L971.5,275" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,191 L294,191.29682 L773.12261,191.027477 C803.42727,191.010441 831.499653,206.959417 847,233 C862.501672,259.04281 890.570141,275 920.877398,275 L954,275 L954,275 L971.5,274.70318" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-deployment-model_sparsezoo-engine_baseline.svg
+++ b/docs/source/sparsification/flow-deployment-model_sparsezoo-engine_baseline.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployment-model_sparsezoo-engine_baseline</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployment-model_sparsezoo-engine_baseline" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,89.5 L250,90.0666667 C279.303105,90.0666667 304.763547,110.20792 311.507878,138.724336 L340.492122,261.275664 C347.236453,289.79208 372.696895,309.933333 402,309.933333 L402,309.933333 L402,309.933333 L426.5,310.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L260.301134,370 C285.514898,370 309.486736,359.053766 326,340 C342.513264,320.946234 366.485102,310 391.698866,310 L402,310 L402,310 L426,310" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,309.902655 L743,310 L785.440252,310 C791.565464,310 797.677721,309.437229 803.699954,308.318784 L844.300046,300.778561 C850.322279,299.660116 856.434536,299.097345 862.559748,299.097345 L903.1025,299.097345 L903.1025,299.097345 L923.5,299" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,90 L246,90.7385159 L694.988148,90.1105142 C741.306134,90.0457291 781.606853,121.796647 792.383619,166.843526 L805.642797,222.26689 C816.407407,267.262959 856.63261,299 902.898397,299 L906,299 L906,299 L923.5,298.261484" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,137.5 L298,138.066667 C327.303105,138.066667 352.763547,158.20792 359.507878,186.724336 L388.492122,309.275664 C395.236453,337.79208 420.696895,357.933333 450,357.933333 L450,357.933333 L450,357.933333 L474.5,358.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L308.301134,418 C333.514898,418 357.486736,407.053766 374,388 C390.513264,368.946234 414.485102,358 439.698866,358 L450,358 L450,358 L474,358" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,357.902655 L791,358 L833.440252,358 C839.565464,358 845.677721,357.437229 851.699954,356.318784 L892.300046,348.778561 C898.322279,347.660116 904.434536,347.097345 910.559748,347.097345 L951.1025,347.097345 L951.1025,347.097345 L971.5,347" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,138 L294,138.738516 L742.988148,138.110514 C789.306134,138.045729 829.606853,169.796647 840.383619,214.843526 L853.642797,270.26689 C864.407407,315.262959 904.63261,347 950.898397,347 L954,347 L954,347 L971.5,346.261484" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-deployment-model_sparsezoo-engine_deepsparse.svg
+++ b/docs/source/sparsification/flow-deployment-model_sparsezoo-engine_deepsparse.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployment-model_sparsezoo-engine_deepsparse</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployment-model_sparsezoo-engine_deepsparse" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,89.5 L250,90.0666667 C279.303105,90.0666667 304.763547,110.20792 311.507878,138.724336 L340.492122,261.275664 C347.236453,289.79208 372.696895,309.933333 402,309.933333 L402,309.933333 L402,309.933333 L426.5,310.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L260.301134,370 C285.514898,370 309.486736,359.053766 326,340 C342.513264,320.946234 366.485102,310 391.698866,310 L402,310 L402,310 L426,310" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,309.309735 L743,310 L746.111245,310 C776.689454,310 805.507703,295.697992 824,271.345133 C842.492297,246.992273 871.310546,232.690265 901.888755,232.690265 L903.1025,232.690265 L903.1025,232.690265 L923.5,232" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,90 L246,90.5053004 L702.956536,90.0679892 C745.49748,90.0272771 783.407443,116.905286 797.448359,157.062306 L800.575398,166.005637 C814.604714,206.129482 852.465701,233 894.97152,233 L906,233 L906,233 L923.5,232.4947" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,137.5 L298,138.066667 C327.303105,138.066667 352.763547,158.20792 359.507878,186.724336 L388.492122,309.275664 C395.236453,337.79208 420.696895,357.933333 450,357.933333 L450,357.933333 L450,357.933333 L474.5,358.5" id="line-model-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L308.301134,418 C333.514898,418 357.486736,407.053766 374,388 C390.513264,368.946234 414.485102,358 439.698866,358 L450,358 L450,358 L474,358" id="line-recipe-sparsification" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,357.309735 L791,358 L794.111245,358 C824.689454,358 853.507703,343.697992 872,319.345133 C890.492297,294.992273 919.310546,280.690265 949.888755,280.690265 L951.1025,280.690265 L951.1025,280.690265 L971.5,280" id="line-sparsification-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,138 L294,138.5053 L750.956536,138.067989 C793.49748,138.027277 831.407443,164.905286 845.448359,205.062306 L848.575398,214.005637 C862.604714,254.129482 900.465701,281 942.97152,281 L954,281 L954,281 L971.5,280.4947" id="line-model-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-deployment-sparsification-engine_baseline.svg
+++ b/docs/source/sparsification/flow-deployment-sparsification-engine_baseline.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployment-sparsification-engine_baseline</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployment-sparsification-engine_baseline" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,116 L246,116.646643 L697.560099,116.093616 C742.683492,116.038353 782.253892,146.209244 794.146776,189.7372 L803.878782,225.356341 C815.759675,268.840411 855.265056,299 900.342989,299 L906,299 L906,299 L923.5,298.353357" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,116.5 L250,116.994872 C279.509219,116.994872 305.356341,136.773186 313.070123,165.256367 L338.929877,260.743633 C346.643659,289.226814 372.490781,309.005128 402,309.005128 L402,309.005128 L402,309.005128 L426.5,309.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,373 L250,373 L258.768944,373 C284.854277,373 309.550781,361.245192 326,341 C342.449219,320.754808 367.145723,309 393.231056,309 L402,309 L402,309 L426,309" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,308.911504 L743,309 L786.265028,309 C791.84356,309 797.41231,308.533201 802.912994,307.604489 L845.087006,300.484007 C850.58769,299.555294 856.15644,299.088496 861.734972,299.088496 L903.1025,299.088496 L903.1025,299.088496 L923.5,299" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,164 L294,164.646643 L745.560099,164.093616 C790.683492,164.038353 830.253892,194.209244 842.146776,237.7372 L851.878782,273.356341 C863.759675,316.840411 903.265056,347 948.342989,347 L954,347 L954,347 L971.5,346.353357" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,164.5 L298,164.994872 C327.509219,164.994872 353.356341,184.773186 361.070123,213.256367 L386.929877,308.743633 C394.643659,337.226814 420.490781,357.005128 450,357.005128 L450,357.005128 L450,357.005128 L474.5,357.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,421 L298,421 L306.768944,421 C332.854277,421 357.550781,409.245192 374,389 C390.449219,368.754808 415.145723,357 441.231056,357 L450,357 L450,357 L474,357" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,356.911504 L791,357 L834.265028,357 C839.84356,357 845.41231,356.533201 850.912994,355.604489 L893.087006,348.484007 C898.58769,347.555294 904.15644,347.088496 909.734972,347.088496 L951.1025,347.088496 L951.1025,347.088496 L971.5,347" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-deployment-sparsification-engine_deepsparse.svg
+++ b/docs/source/sparsification/flow-deployment-sparsification-engine_deepsparse.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-deployment-sparsification-engine_deepsparse</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-deployment-sparsification-engine_deepsparse" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,116 L246,116.413428 L710.382019,116.049813 C748.963792,116.019604 783.838495,139.022079 799,174.5 C814.163642,209.982922 849.030777,233 887.618001,233 L906,233 L906,233 L923.5,232.586572" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,116.5 L250,116.994872 C279.509219,116.994872 305.356341,136.773186 313.070123,165.256367 L338.929877,260.743633 C346.643659,289.226814 372.490781,309.005128 402,309.005128 L402,309.005128 L402,309.005128 L426.5,309.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,373 L250,373 L258.768944,373 C284.854277,373 309.550781,361.245192 326,341 C342.449219,320.754808 367.145723,309 393.231056,309 L402,309 L402,309 L426,309" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,308.327434 L743,309 L746.896847,309 C777.029166,309 805.477554,295.103395 824,271.336283 C842.522446,247.569171 870.970834,233.672566 901.103153,233.672566 L903.1025,233.672566 L903.1025,233.672566 L923.5,233" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,164 L294,164.413428 L758.382019,164.049813 C796.963792,164.019604 831.838495,187.022079 847,222.5 C862.163642,257.982922 897.030777,281 935.618001,281 L954,281 L954,281 L971.5,280.586572" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,164.5 L298,164.994872 C327.509219,164.994872 353.356341,184.773186 361.070123,213.256367 L386.929877,308.743633 C394.643659,337.226814 420.490781,357.005128 450,357.005128 L450,357.005128 L450,357.005128 L474.5,357.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,421 L298,421 L306.768944,421 C332.854277,421 357.550781,409.245192 374,389 C390.449219,368.754808 415.145723,357 441.231056,357 L450,357 L450,357 L474,357" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,356.327434 L791,357 L794.896847,357 C825.029166,357 853.477554,343.103395 872,319.336283 C890.522446,295.569171 918.970834,281.672566 949.103153,281.672566 L951.1025,281.672566 L951.1025,281.672566 L971.5,281" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-overview-deployment.svg
+++ b/docs/source/sparsification/flow-overview-deployment.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-overview-deployment</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-overview-deployment" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,371 L250,371 L258.768944,371 C284.854277,371 309.550781,359.245192 326,339 C342.449219,318.754808 367.145723,307 393.231056,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,306.637168 L743,307 L763.412857,307 C783.751435,307 803.606499,300.798342 820.329353,289.222336 L827.670647,284.140496 C844.393501,272.56449 864.248565,266.362832 884.587143,266.362832 L903.1025,266.362832 L903.1025,266.362832 L923.5,266" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117 L246,117.526502 L671.486923,117.526502 C704.919323,117.526502 736.140132,134.233717 754.687382,162.049628 L794.312618,221.476874 C812.859868,249.292784 844.080677,266 877.513077,266 L906,266 L906,266 L923.5,265.473498" id="line-model-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,419 L298,419 L306.768944,419 C332.854277,419 357.550781,407.245192 374,387 C390.449219,366.754808 415.145723,355 441.231056,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,354.637168 L791,355 L811.412857,355 C831.751435,355 851.606499,348.798342 868.329353,337.222336 L875.670647,332.140496 C892.393501,320.56449 912.248565,314.362832 932.587143,314.362832 L951.1025,314.362832 L951.1025,314.362832 L971.5,314" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.526502 L719.486923,165.526502 C752.919323,165.526502 784.140132,182.233717 802.687382,210.049628 L842.312618,269.476874 C860.859868,297.292784 892.080677,314 925.513077,314 L954,314 L954,314 L971.5,313.473498" id="line-model-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-overview-model_recipe.svg
+++ b/docs/source/sparsification/flow-overview-model_recipe.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-overview-model_recipe</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-overview-model_recipe" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L259.155784,370 C285.021202,370 309.534979,358.448006 326,338.5 C342.465021,318.551994 366.978798,307 392.844216,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L307.155784,418 C333.021202,418 357.534979,406.448006 374,386.5 C390.465021,366.551994 414.978798,355 440.844216,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-overview-sparsification.svg
+++ b/docs/source/sparsification/flow-overview-sparsification.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-overview-sparsification</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-overview-sparsification" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L259.155784,370 C285.021202,370 309.534979,358.448006 326,338.5 C342.465021,318.551994 366.978798,307 392.844216,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L307.155784,418 C333.021202,418 357.534979,406.448006 374,386.5 C390.465021,366.551994 414.978798,355 440.844216,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-overview-sparsification_recipe.svg
+++ b/docs/source/sparsification/flow-overview-sparsification_recipe.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-overview-sparsification_recipe</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-overview-sparsification_recipe" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L259.155784,370 C285.021202,370 309.534979,358.448006 326,338.5 C342.465021,318.551994 366.978798,307 392.844216,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L307.155784,418 C333.021202,418 357.534979,406.448006 374,386.5 C390.465021,366.551994 414.978798,355 440.844216,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-overview.svg
+++ b/docs/source/sparsification/flow-overview.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-overview</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-overview" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#000000" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L259.155784,370 C285.021202,370 309.534979,358.448006 326,338.5 C342.465021,318.551994 366.978798,307 392.844216,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L307.155784,418 C333.021202,418 357.534979,406.448006 374,386.5 C390.465021,366.551994 414.978798,355 440.844216,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-simplified.svg
+++ b/docs/source/sparsification/flow-simplified.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="767px" height="522px" viewBox="0 0 767 522" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="863px" height="618px" viewBox="0 0 863 618" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-simplified</title>
     <defs>
         <rect id="path-1" x="0" y="0" width="113" height="90"></rect>
@@ -12,48 +12,49 @@
         </mask>
     </defs>
     <g id="flow-simplified" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <line x1="112.248196" y1="180.5" x2="112.744587" y2="338.5" id="Line-4" stroke="#000000" stroke-width="2" stroke-linecap="square"></line>
-        <line x1="387.5" y1="260.5" x2="541" y2="261" id="Line-2" stroke="#000000" stroke-width="2" stroke-linecap="square"></line>
-        <path d="M226.5,90.5 L245.3,90.9358974 C268.78874,90.9358974 289.243685,106.969271 294.853928,129.778174 L317.346072,221.221826 C322.956315,244.030729 343.41126,260.064103 366.9,260.064103 L366.9,260.064103 L366.9,260.064103 L386.5,260.5" id="Line" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226,431 L244.60804,431 C268.369744,431 289.069806,414.798192 294.777983,391.732302 L317.412972,300.267698 C323.121149,277.201808 343.821211,261 367.582915,261 L367.582915,261 L367.582915,261 L387,261" id="Line-Copy" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="863" height="618"></rect>
+        <line x1="160.284572" y1="228.5" x2="160.853717" y2="386.5" id="Line-4" stroke="#000000" stroke-width="2" stroke-linecap="square"></line>
+        <line x1="435.5" y1="308.5" x2="589" y2="309" id="Line-2" stroke="#000000" stroke-width="2" stroke-linecap="square"></line>
+        <path d="M274.5,138.5 L293.3,138.935897 C316.78874,138.935897 337.243685,154.969271 342.853928,177.778174 L365.346072,269.221826 C370.956315,292.030729 391.41126,308.064103 414.9,308.064103 L414.9,308.064103 L414.9,308.064103 L434.5,308.5" id="Line" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274,479 L292.60804,479 C316.369744,479 337.069806,462.798192 342.777983,439.732302 L365.412972,348.267698 C371.121149,325.201808 391.821211,309 415.582915,309 L415.582915,309 L415.582915,309 L435,309" id="Line-Copy" stroke="#000000" stroke-width="2" stroke-linecap="square"></path>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <rect id="border" stroke="#000000" stroke-width="2" fill="#FFFFFF" x="1" y="1" width="224" height="179"></rect>
             <text id="title" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
                 <tspan x="70.784" y="86">Trained</tspan>
                 <tspan x="77.468" y="114">Model</tspan>
             </text>
         </g>
-        <g id="card-sparsification" transform="translate(0.000000, 341.000000)">
+        <g id="card-sparsification" transform="translate(48.000000, 389.000000)">
             <rect id="border" stroke="#000000" stroke-width="2" fill="#FFFFFF" x="1" y="1" width="224" height="179"></rect>
             <text id="title" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
                 <tspan x="55.232" y="86">Sparsified</tspan>
                 <tspan x="77.468" y="114">Model</tspan>
             </text>
         </g>
-        <g id="card-recipe" transform="translate(56.000000, 215.000000)">
+        <g id="card-recipe" transform="translate(104.000000, 263.000000)">
             <use id="border" stroke="#000000" mask="url(#mask-2)" stroke-width="4" fill-opacity="0.8" fill="#FFFFFF" stroke-dasharray="6,6" xlink:href="#path-1"></use>
             <text id="title" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
                 <tspan x="16.744" y="54">Recipe</tspan>
             </text>
         </g>
-        <g id="card-engine" transform="translate(387.000000, 216.000000)">
+        <g id="card-engine" transform="translate(435.000000, 264.000000)">
             <use id="border" stroke="#000000" mask="url(#mask-4)" stroke-width="4" fill-opacity="0.8" fill="#FFFFFF" stroke-dasharray="6,6" xlink:href="#path-3"></use>
             <text id="title" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
                 <tspan x="17.176" y="51">Engine</tspan>
             </text>
         </g>
-        <g id="card-deployment" transform="translate(541.000000, 170.000000)">
+        <g id="card-deployment" transform="translate(589.000000, 218.000000)">
             <rect id="border" stroke="#000000" stroke-width="2" fill="#FFFFFF" x="1" y="1" width="224" height="179"></rect>
             <text id="title" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
                 <tspan x="59.012" y="86">Deployed</tspan>
                 <tspan x="77.468" y="114">Model</tspan>
             </text>
         </g>
-        <text id="baseline-path" transform="translate(329.000000, 159.000000) rotate(76.000000) translate(-329.000000, -159.000000) " font-family="HelveticaNeue-Italic, Helvetica Neue" font-size="16" font-style="italic" font-weight="normal" fill="#2A303C">
-            <tspan x="281.576" y="165">baseline path</tspan>
+        <text id="baseline-path" transform="translate(377.000000, 207.000000) rotate(76.000000) translate(-377.000000, -207.000000) " font-family="HelveticaNeue-Italic, Helvetica Neue" font-size="16" font-style="italic" font-weight="normal" fill="#2A303C">
+            <tspan x="329.576" y="213">baseline path</tspan>
         </text>
-        <text id="sparsified-path" transform="translate(329.000000, 360.000000) rotate(-74.000000) translate(-329.000000, -360.000000) " font-family="HelveticaNeue-Italic, Helvetica Neue" font-size="16" font-style="italic" font-weight="normal" fill="#2A303C">
-            <tspan x="276.688" y="366">sparsified path</tspan>
+        <text id="sparsified-path" transform="translate(377.000000, 408.000000) rotate(-74.000000) translate(-377.000000, -408.000000) " font-family="HelveticaNeue-Italic, Helvetica Neue" font-size="16" font-style="italic" font-weight="normal" fill="#2A303C">
+            <tspan x="324.688" y="414">sparsified path</tspan>
         </text>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparseml.svg
+++ b/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparseml.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_baseline-recipe_sparseml</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_baseline-recipe_sparseml" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,147 L246,147.424028 L702.140045,147.050638 C740.046728,147.019608 774.712233,168.424465 791.664622,202.329245 L796.36068,211.72136 C813.299881,245.599762 847.926193,267 885.803399,267 L906,267 L906,267 L923.5,266.575972" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,147.5 L250,147.910256 C279.823734,147.910256 306.265256,167.089106 315.526301,195.4385 L336.473699,259.5615 C345.734744,287.910894 372.176266,307.089744 402,307.089744 L402,307.089744 L402,307.089744 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,435 L250,435 C280.228258,435 307.44163,416.682142 318.818852,388.676671 L333.181148,353.323329 C344.55837,325.317858 371.771742,307 402,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,195 L294,195.424028 L750.140045,195.050638 C788.046728,195.019608 822.712233,216.424465 839.664622,250.329245 L844.36068,259.72136 C861.299881,293.599762 895.926193,315 933.803399,315 L954,315 L954,315 L971.5,314.575972" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,195.5 L298,195.910256 C327.823734,195.910256 354.265256,215.089106 363.526301,243.4385 L384.473699,307.5615 C393.734744,335.910894 420.176266,355.089744 450,355.089744 L450,355.089744 L450,355.089744 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,483 L298,483 C328.228258,483 355.44163,464.682142 366.818852,436.676671 L381.181148,401.323329 C392.55837,373.317858 419.771742,355 450,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparsezoo.svg
+++ b/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparsezoo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_baseline-recipe_sparsezoo</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_baseline-recipe_sparsezoo" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,146 L246,146.427562 L705.063664,146.052985 C744.556538,146.020761 780.369193,169.234673 796.464064,205.299106 L797.559568,207.753846 C813.642382,243.791264 849.415067,267 888.878372,267 L906,267 L906,267 L923.5,266.572438" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,146.5 L250,146.912821 C279.812758,146.912821 306.233451,166.113571 315.439086,194.469467 L336.560914,259.530533 C345.766549,287.886429 372.187242,307.087179 402,307.087179 L402,307.087179 L402,307.087179 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,308 L250,308 L299.03855,308 C299.679502,308 300.320439,307.993838 300.961272,307.981514 L351.038728,307.018486 C351.679561,307.006162 352.320498,307 352.96145,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,194 L294,194.427562 L753.063664,194.052985 C792.556538,194.020761 828.369193,217.234673 844.464064,253.299106 L845.559568,255.753846 C861.642382,291.791264 897.415067,315 936.878372,315 L954,315 L954,315 L971.5,314.572438" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,194.5 L298,194.912821 C327.812758,194.912821 354.233451,214.113571 363.439086,242.469467 L384.560914,307.530533 C393.766549,335.886429 420.187242,355.087179 450,355.087179 L450,355.087179 L450,355.087179 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,356 L298,356 L347.03855,356 C347.679502,356 348.320439,355.993838 348.961272,355.981514 L399.038728,355.018486 C399.679561,355.006162 400.320498,355 400.96145,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparsify.svg
+++ b/docs/source/sparsification/flow-sparsification-model_baseline-recipe_sparsify.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_baseline-recipe_sparsify</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_baseline-recipe_sparsify" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,147 L246,147.424028 L709.000021,147.0522 C748.355087,147.020595 783.863431,170.672235 799,207 C814.138782,243.333077 849.639167,267 889,267 L906,267 L906,267 L923.5,266.575972" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,147.5 L250,147.910256 C279.823734,147.910256 306.265256,167.089106 315.526301,195.4385 L336.473699,259.5615 C345.734744,287.910894 372.176266,307.089744 402,307.089744 L402,307.089744 L402,307.089744 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,372 L250,372 L258.379692,372 C284.686222,372 309.566441,360.041949 326,339.5 C342.433559,318.958051 367.313778,307 393.620308,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,195 L294,195.424028 L757.000021,195.0522 C796.355087,195.020595 831.863431,218.672235 847,255 C862.138782,291.333077 897.639167,315 937,315 L954,315 L954,315 L971.5,314.575972" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,195.5 L298,195.910256 C327.823734,195.910256 354.265256,215.089106 363.526301,243.4385 L384.473699,307.5615 C393.734744,335.910894 420.176266,355.089744 450,355.089744 L450,355.089744 L450,355.089744 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,420 L298,420 L306.379692,420 C332.686222,420 357.566441,408.041949 374,387.5 C390.433559,366.958051 415.313778,355 441.620308,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparseml.svg
+++ b/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparseml.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_sparsezoo-recipe_sparseml</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_sparsezoo-recipe_sparseml" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,86 L246,86.639576 L665.815895,86.639576 C702.315266,86.639576 735.915414,106.525523 753.47814,138.521691 L795.52186,215.117885 C813.084586,247.114053 846.684734,267 883.184105,267 L906,267 L906,267 L923.5,266.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,85.5 L250,86.0692308 C279.296546,86.0692308 304.744722,106.221665 311.458769,134.738488 L340.541231,258.261512 C347.255278,286.778335 372.703454,306.930769 402,306.930769 L402,306.930769 L402,306.930769 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,433 L250,433 C280.258878,433 307.530995,414.751821 319.074383,386.781303 L332.925617,353.218697 C344.469005,325.248179 371.741122,307 402,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,134 L294,134.639576 L713.815895,134.639576 C750.315266,134.639576 783.915414,154.525523 801.47814,186.521691 L843.52186,263.117885 C861.084586,295.114053 894.684734,315 931.184105,315 L954,315 L954,315 L971.5,314.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,133.5 L298,134.069231 C327.296546,134.069231 352.744722,154.221665 359.458769,182.738488 L388.541231,306.261512 C395.255278,334.778335 420.703454,354.930769 450,354.930769 L450,354.930769 L450,354.930769 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,481 L298,481 C328.258878,481 355.530995,462.751821 367.074383,434.781303 L380.925617,401.218697 C392.469005,373.248179 419.741122,355 450,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparsezoo.svg
+++ b/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparsezoo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_sparsezoo-recipe_sparsezoo</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_sparsezoo-recipe_sparsezoo" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,86 L246,86.639576 L665.815895,86.639576 C702.315266,86.639576 735.915414,106.525523 753.47814,138.521691 L795.52186,215.117885 C813.084586,247.114053 846.684734,267 883.184105,267 L906,267 L906,267 L923.5,266.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,85.5 L250,86.0692308 C279.296546,86.0692308 304.744722,106.221665 311.458769,134.738488 L340.541231,258.261512 C347.255278,286.778335 372.703454,306.930769 402,306.930769 L402,306.930769 L402,306.930769 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,308 L250,308 L299.03855,308 C299.679502,308 300.320439,307.993838 300.961272,307.981514 L351.038728,307.018486 C351.679561,307.006162 352.320498,307 352.96145,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,134 L294,134.639576 L713.815895,134.639576 C750.315266,134.639576 783.915414,154.525523 801.47814,186.521691 L843.52186,263.117885 C861.084586,295.114053 894.684734,315 931.184105,315 L954,315 L954,315 L971.5,314.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,133.5 L298,134.069231 C327.296546,134.069231 352.744722,154.221665 359.458769,182.738488 L388.541231,306.261512 C395.255278,334.778335 420.703454,354.930769 450,354.930769 L450,354.930769 L450,354.930769 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,356 L298,356 L347.03855,356 C347.679502,356 348.320439,355.993838 348.961272,355.981514 L399.038728,355.018486 C399.679561,355.006162 400.320498,355 400.96145,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparsify.svg
+++ b/docs/source/sparsification/flow-sparsification-model_sparsezoo-recipe_sparsify.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification-model_sparsezoo-recipe_sparsify</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification-model_sparsezoo-recipe_sparsify" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,86 L246,86.639576 L665.815895,86.639576 C702.315266,86.639576 735.915414,106.525523 753.47814,138.521691 L795.52186,215.117885 C813.084586,247.114053 846.684734,267 883.184105,267 L906,267 L906,267 L923.5,266.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,85.5 L250,86.0692308 C279.296546,86.0692308 304.744722,106.221665 311.458769,134.738488 L340.541231,258.261512 C347.255278,286.778335 372.703454,306.930769 402,306.930769 L402,306.930769 L402,306.930769 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,372 L250,372 L258.379692,372 C284.686222,372 309.566441,360.041949 326,339.5 C342.433559,318.958051 367.313778,307 393.620308,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,134 L294,134.639576 L713.815895,134.639576 C750.315266,134.639576 783.915414,154.525523 801.47814,186.521691 L843.52186,263.117885 C861.084586,295.114053 894.684734,315 931.184105,315 L954,315 L954,315 L971.5,314.360424" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,133.5 L298,134.069231 C327.296546,134.069231 352.744722,154.221665 359.458769,182.738488 L388.541231,306.261512 C395.255278,334.778335 420.703454,354.930769 450,354.930769 L450,354.930769 L450,354.930769 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,420 L298,420 L306.379692,420 C332.686222,420 357.566441,408.041949 374,387.5 C390.433559,366.958051 415.313778,355 441.620308,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification_type-sparseml_oneshot.svg
+++ b/docs/source/sparsification/flow-sparsification_type-sparseml_oneshot.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification_type-sparseml_oneshot</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification_type-sparseml_oneshot" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,117.987179 C279.534212,117.987179 305.428378,137.719923 313.26208,166.196279 L338.73792,258.803721 C346.571622,287.280077 372.465788,307.012821 402,307.012821 L402,307.012821 L402,307.012821 L426.5,307.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L259.155784,370 C285.021202,370 309.534979,358.448006 326,338.5 C342.465021,318.551994 366.978798,307 392.844216,307 L402,307 L402,307 L426,307" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,307.637168 L743,308 L763.412857,308 C783.751435,308 803.606499,301.798342 820.329353,290.222336 L827.670647,285.140496 C844.393501,273.56449 864.248565,267.362832 884.587143,267.362832 L903.1025,267.362832 L903.1025,267.362832 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.987179 C327.534212,165.987179 353.428378,185.719923 361.26208,214.196279 L386.73792,306.803721 C394.571622,335.280077 420.465788,355.012821 450,355.012821 L450,355.012821 L450,355.012821 L474.5,355.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L307.155784,418 C333.021202,418 357.534979,406.448006 374,386.5 C390.465021,366.551994 414.978798,355 440.844216,355 L450,355 L450,355 L474,355" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,355.637168 L791,356 L811.412857,356 C831.751435,356 851.606499,349.798342 868.329353,338.222336 L875.670647,333.140496 C892.393501,321.56449 912.248565,315.362832 932.587143,315.362832 L951.1025,315.362832 L951.1025,315.362832 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification_type-sparseml_training.svg
+++ b/docs/source/sparsification/flow-sparsification_type-sparseml_training.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification_type-sparseml_training</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification_type-sparseml_training" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,117.817949 C280.30024,117.817949 307.651781,135.970932 319.421001,163.892071 L332.578999,195.107929 C344.348219,223.029068 371.69976,241.182051 402,241.182051 L402,241.182051 L402,241.182051 L426.5,241.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 C280.213189,370 307.397667,351.648095 318.693429,323.625916 L333.306571,287.374084 C344.602333,259.351905 371.786811,241 402,241 L402,241 L402,241 L426,241" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M724.5,266.769912 L743,267 L773.665157,267 C787.502723,267 801.189696,264.128153 813.86022,258.566134 L834.13978,249.663954 C846.810304,244.101936 860.497277,241.230088 874.334843,241.230088 L903.1025,241.230088 L903.1025,241.230088 L923.5,241" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square" transform="translate(824.000000, 254.000000) scale(1, -1) translate(-824.000000, -254.000000) "></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,165.817949 C328.30024,165.817949 355.651781,183.970932 367.421001,211.892071 L380.578999,243.107929 C392.348219,271.029068 419.69976,289.182051 450,289.182051 L450,289.182051 L450,289.182051 L474.5,289.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 C328.213189,418 355.397667,399.648095 366.693429,371.625916 L381.306571,335.374084 C392.602333,307.351905 419.786811,289 450,289 L450,289 L450,289 L474,289" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M772.5,314.769912 L791,315 L821.665157,315 C835.502723,315 849.189696,312.128153 861.86022,306.566134 L882.13978,297.663954 C894.810304,292.101936 908.497277,289.230088 922.334843,289.230088 L951.1025,289.230088 L951.1025,289.230088 L971.5,289" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square" transform="translate(872.000000, 302.000000) scale(1, -1) translate(-872.000000, -302.000000) "></path>
     </g>
 </svg>

--- a/docs/source/sparsification/flow-sparsification_type-sparsify_oneshot.svg
+++ b/docs/source/sparsification/flow-sparsification_type-sparsify_oneshot.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="1222px" height="465px" viewBox="0 0 1222 465" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1318px" height="561px" viewBox="0 0 1318 561" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>flow-sparsification_type-sparsify_oneshot</title>
     <defs>
         <filter id="filter-1">
@@ -34,7 +34,8 @@
         </filter>
     </defs>
     <g id="flow-sparsification_type-sparsify_oneshot" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="card-model">
+        <rect fill="#FFFFFF" x="0" y="0" width="1318" height="561"></rect>
+        <g id="card-model" transform="translate(48.000000, 48.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -78,7 +79,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="179"></rect>
         </g>
-        <g id="card-recipe" transform="translate(0.000000, 221.000000)">
+        <g id="card-recipe" transform="translate(48.000000, 269.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="223" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -147,7 +148,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="224" height="242"></rect>
         </g>
-        <g id="card-sparsification" transform="translate(426.000000, 158.000000)">
+        <g id="card-sparsification" transform="translate(474.000000, 206.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -212,7 +213,7 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="242"></rect>
         </g>
-        <g id="card-deployment" transform="translate(924.000000, 134.000000)">
+        <g id="card-deployment" transform="translate(972.000000, 182.000000)">
             <g id="title" transform="translate(1.000000, 1.000000)">
                 <rect id="container" stroke="#000000" fill="#FFFFFF" x="0.5" y="0.5" width="295" height="51"></rect>
                 <text font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="24" font-weight="bold" fill="#2A303C">
@@ -246,9 +247,9 @@
             </g>
             <rect id="border" stroke="#062EF5" stroke-width="2" x="1" y="1" width="296" height="195"></rect>
         </g>
-        <path d="M226.5,117 L246,117.530035 L671.288437,117.530035 C704.830102,117.530035 736.137831,134.345906 754.659561,162.30997 L794.340439,222.220066 C812.862169,250.184129 844.169898,267 877.711563,267 L906,267 L906,267 L923.5,266.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M226.5,117.5 L250,118.148718 C279.115286,118.148718 304.225407,138.601523 310.116028,167.114685 L341.883972,320.885315 C347.774593,349.398477 372.884714,369.851282 402,369.851282 L402,369.851282 L402,369.851282 L426.5,370.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
-        <path d="M227,370 L250,370 L299.519242,370 C299.839745,370 300.160247,369.998459 300.480736,369.995378 L351.519264,369.504622 C351.839753,369.501541 352.160255,369.5 352.480758,369.5 L402,369.5 L402,369.5 L426,369.5" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square" transform="translate(326.500000, 369.750000) scale(1, -1) translate(-326.500000, -369.750000) "></path>
-        <path d="M724.5,369.088496 L743,370 C774.951002,370 804.466153,352.925279 820.393644,325.227237 L828.552255,311.039342 C843.894579,284.35891 872.32536,267.911504 903.1025,267.911504 L903.1025,267.911504 L903.1025,267.911504 L923.5,267" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165 L294,165.530035 L719.288437,165.530035 C752.830102,165.530035 784.137831,182.345906 802.659561,210.30997 L842.340439,270.220066 C860.862169,298.184129 892.169898,315 925.711563,315 L954,315 L954,315 L971.5,314.469965" id="line-model-deployment" stroke-opacity="0.5" stroke="#2A303C" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M274.5,165.5 L298,166.148718 C327.115286,166.148718 352.225407,186.601523 358.116028,215.114685 L389.883972,368.885315 C395.774593,397.398477 420.884714,417.851282 450,417.851282 L450,417.851282 L450,417.851282 L474.5,418.5" id="line-model-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
+        <path d="M275,418 L298,418 L347.519242,418 C347.839745,418 348.160247,417.998459 348.480736,417.995378 L399.519264,417.504622 C399.839753,417.501541 400.160255,417.5 400.480758,417.5 L450,417.5 L450,417.5 L474,417.5" id="line-recipe-sparsification" stroke="#062EF5" stroke-width="2" stroke-linecap="square" transform="translate(374.500000, 417.750000) scale(1, -1) translate(-374.500000, -417.750000) "></path>
+        <path d="M772.5,417.088496 L791,418 C822.951002,418 852.466153,400.925279 868.393644,373.227237 L876.552255,359.039342 C891.894579,332.35891 920.32536,315.911504 951.1025,315.911504 L951.1025,315.911504 L951.1025,315.911504 L971.5,315" id="line-sparsification-deployment" stroke="#062EF5" stroke-width="2" stroke-linecap="square"></path>
     </g>
 </svg>


### PR DESCRIPTION
(harder than I thought to reliably set color and padding in markdown and have it work everywhere)