### PR TITLE
Fix latest version not found for docs build because of non standard…

### DIFF
--- a/utils/docs_builder.py
+++ b/utils/docs_builder.py
@@ -115,7 +115,7 @@ def _get_latest_folder(folders: List[str]) -> str:
     versioned_folders = [
         (folder, version.parse(folder[1:]))
         for folder in folders
-        if re.match(r"^v[0-9]+\.[0-9]+\.[0-9]+$", folder)
+        if re.match(r"^v\.?[0-9]+\.[0-9]+\.[0-9]+$", folder)
     ]
     versioned_folders.sort(key=lambda ver: ver[1])
 


### PR DESCRIPTION
…version tags. ex: v.0.3.0 instead of v0.3.0