### PR TITLE
use-cases/deploying-deepsparse/docker fixes

### DIFF
--- a/src/content/use-cases/deploying-deepsparse/docker.mdx
+++ b/src/content/use-cases/deploying-deepsparse/docker.mdx
@@ -16,8 +16,8 @@ This image is based off the latest official Ubuntu image.
 You can access the already built image detailed at https://github.com/orgs/neuralmagic/packages/container/package/deepsparse:
 
 ```bash
-$ docker pull ghcr.io/neuralmagic/deepsparse:1.0.2-debian11
-$ docker tag ghcr.io/neuralmagic/deepsparse:1.0.2-debian11 deepsparse_docker
+docker pull ghcr.io/neuralmagic/deepsparse:1.0.2-debian11
+docker tag ghcr.io/neuralmagic/deepsparse:1.0.2-debian11 deepsparse_docker
 ```
 
 ## Extend
@@ -32,7 +32,7 @@ from ghcr.io/neuralmagic/deepsparse:1.0.2-debian11
 
 ## Build
 
-In order to build and launch this image, run from the root directory under the DeepSparse Repo:
+In order to build and launch this image, run from the `docker/` directory under the DeepSparse Repo:
 ```bash
 $ docker build -t deepsparse_docker . && docker run -it deepsparse_docker ${python_command}
 ```
@@ -40,11 +40,11 @@ $ docker build -t deepsparse_docker . && docker run -it deepsparse_docker ${pyth
 For example:
 
 ```bash
-$ docker build -t deepsparse_docker . && docker run -it deepsparse_docker deepsparse.server --task question_answering --model_path "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni"
+docker build -t deepsparse_docker . && docker run -it deepsparse_docker deepsparse.server --task question_answering --model_path "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni"
 ````
 
 If you want to use a specific branch from deepsparse you can use the `GIT_CHECKOUT` build arg:
 
 ```bash
-$ docker build --build-arg GIT_CHECKOUT=main -t deepsparse_docker .
+docker build --build-arg GIT_CHECKOUT=main -t deepsparse_docker .
 ```


### PR DESCRIPTION
* specify correct directory for build
* remove preceding `$` from bash commands to better support copy button