### PR TITLE
fix yolo+server install command

### DIFF
--- a/src/content/get-started/install/deepsparse.mdx
+++ b/src/content/get-started/install/deepsparse.mdx
@@ -38,5 +38,5 @@ To use YOLO models, install with the following extra option:
 
 ```bash
 pip install deepsparse[yolo]         # just yolo requirements
-pip install deepsparse[yolo, server] # both yolo + server requirements
+pip install deepsparse[yolo,server] # both yolo + server requirements
 ```


### PR DESCRIPTION
spaces are not allowed between extras for pip (without enclosing entire requirement in quotes)