### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/get-started/install.mdx
+++ b/src/content/get-started/install.mdx
@@ -9,17 +9,19 @@ index: 0
 
 The Deep Sparse Platform is made up of core libraries that are available as Python APIs and CLIs.
 All Python APIs and CLIs are installed through pip utilizing [PyPI](https://pypi.org/user/neuralmagic/).
-It is recommended to install in a [virtual environment](https://docs.python.org/3/library/venv.html) to encapsulate your local environment.
+We recommend you install in a [virtual environment](https://docs.python.org/3/library/venv.html) to encapsulate your local environment.
 
-## Quick Start
+## Installing the Deep Sparse Platform
 
-To begin using the Deep Sparse Platform, run the following commands which install standard setups for deployment with the [DeepSparse Engine](../../products/deepsparse) and model training/optimization with [SparseML](../../products/sparseml):
+To begin using the Deep Sparse Platform, run the following command, which installs standard setups for deployment with the [DeepSparse Engine](../../products/deepsparse) and model training/optimization with [SparseML](../../products/sparseml):
 
 ```bash
 pip install deepsparse[server] sparseml[torch,torchvision]
 ```
 
-## Package Installations
+Now, you are ready to install one of the Neural Magic products.
+
+## Installing Products
 
 <LinkCards>
   <LinkCard href="./deepsparse" heading="DeepSparse">

--- a/src/content/get-started/install/deepsparse-ent.mdx
+++ b/src/content/get-started/install/deepsparse-ent.mdx
@@ -39,3 +39,4 @@ To use YOLO models, install with the following extra option:
 pip install deepsparse-ent[yolo]         # just yolo requirements
 pip install deepsparse-ent[yolo,server] # both yolo + server requirements
 ```
+ 

--- a/src/content/get-started/install/deepsparse-ent.mdx
+++ b/src/content/get-started/install/deepsparse-ent.mdx
@@ -13,11 +13,7 @@ The engine accepts models in the open-source [ONNX format](https://onnx.ai/), wh
 Currently, DeepSparse is tested on Python 3.7-3.10, ONNX 1.5.0-1.10.1, ONNX opset version 11+ and is [manylinux compliant](https://peps.python.org/pep-0513/).
 It is limited to Linux systems running on x86 CPU architectures.
 
-The DeepSparse Engine is available in two editions:
-1. [**The Community Edition**](/products/deepsparse) is open-source and free for evaluation, research, and non-production use with our [Engine Community License](https://neuralmagic.com/legal/engine-license-agreement/).
-2. [**The Enterprise Edition**](/products/deepsparse-ent) requires a Trial License or [can be fully licensed](https://neuralmagic.com/legal/master-software-license-and-service-agreement/) for production, commercial applications.
-
-## General Install
+## Installing DeepSparse Enterprise
 
 Use the following command to install with pip:
 
@@ -25,7 +21,7 @@ Use the following command to install with pip:
 pip install deepsparse-ent
 ```
 
-## Server Install
+## Installing the Server
 
 The [DeepSparse Server](/use-cases/deploying-deepsparse/deepsparse-server) allows you to serve models and pipelines through an HTTP interface using the deepsparse.server CLI.
 To install, use the following extra option:
@@ -34,7 +30,7 @@ To install, use the following extra option:
 pip install deepsparse-ent[server]
 ```
 
-## YOLO Install
+## Installing YOLO
 
 The [Ultralytics YOLOv5](/use-cases/object-detection/deploying) models require extra dependencies for deployment.
 To use YOLO models, install with the following extra option:

--- a/src/content/get-started/install/deepsparse.mdx
+++ b/src/content/get-started/install/deepsparse.mdx
@@ -10,14 +10,10 @@ index: 1000
 The [DeepSparse Engine](/products/deepsparse) enables GPU-class performance on CPUs, leveraging sparsity within models to reduce FLOPs and the unique cache hierarchy on CPUs to reduce memory movement.
 The engine accepts models in the open-source [ONNX format](https://onnx.ai/), which are easily created from PyTorch and TensorFlow models.
 
-Currently, DeepSparse is tested on Python 3.7-3.10, ONNX 1.5.0-1.10.1, ONNX opset version 11+ and is [manylinux compliant](https://peps.python.org/pep-0513/).
-It is limited to Linux systems running on x86 CPU architectures.
+Currently, DeepSparse is tested on Python 3.7-3.10, ONNX 1.5.0-1.10.1, and ONNX opset version 11+. It is [manylinux compliant](https://peps.python.org/pep-0513/).
+DeepSparse is limited to Linux systems running on x86 CPU architectures.
 
-The DeepSparse Engine is available in two editions:
-1. [**The Community Edition**](/products/deepsparse) is open-source and free for evaluation, research, and non-production use with our [Engine Community License](https://neuralmagic.com/legal/engine-license-agreement/).
-2. [**The Enterprise Edition**](/products/deepsparse-ent) requires a Trial License or [can be fully licensed](https://neuralmagic.com/legal/master-software-license-and-service-agreement/) for production, commercial applications.
-
-## General Installation
+## Installing DeepSparse Community
 
 Use the following command to install the Community Edition with pip:
 
@@ -25,7 +21,7 @@ Use the following command to install the Community Edition with pip:
 pip install deepsparse
 ```
 
-## Server Install
+## Installing the Server
 
 The [DeepSparse Server](/use-cases/deploying-deepsparse/deepsparse-server) allows you to serve models and pipelines through an HTTP interface using the deepsparse.server CLI.
 To install, use the following extra option:
@@ -34,7 +30,7 @@ To install, use the following extra option:
 pip install deepsparse[server]
 ```
 
-## YOLO Install
+## Installing YOLO
 
 The [Ultralytics YOLOv5](/use-cases/object-detection/deploying) models require extra dependencies for deployment.
 To use YOLO models, install with the following extra option:

--- a/src/content/get-started/install/deepsparse.mdx
+++ b/src/content/get-started/install/deepsparse.mdx
@@ -39,3 +39,4 @@ To use YOLO models, install with the following extra option:
 pip install deepsparse[yolo]         # just yolo requirements
 pip install deepsparse[yolo,server] # both yolo + server requirements
 ```
+ 

--- a/src/content/get-started/try-a-model.mdx
+++ b/src/content/get-started/try-a-model.mdx
@@ -10,9 +10,9 @@ index: 2000
 DeepSparse Engine supports fast inference on CPUs for sparse and dense models. For sparse models in particular, it achieves GPU-level performance in many use cases.
 
 Around the engine, the DeepSparse package includes various utilities to simplify benchmarking performance and model deployment. For instance:
-1. Trained models are passed in the open ONNX file format, enabling easy exporting from common packages like PyTorch, Keras, and TensorFlow.
-2. Benchmaking latency and performance is available via a single CLI call, with various arguments to test scenarios.
-3. `Pipelines` utilities wrap the model execution with input pre-processing and output post-processing, simplifying deployment and adding functionality like multi-stream, bucketing and dynamic shape.
+- Trained models are passed in the open ONNX file format, enabling easy exporting from common packages like PyTorch, Keras, and TensorFlow.
+- Benchmaking latency and performance is available via a single CLI call, with various arguments to test scenarios.
+- Pipelines utilities wrap the model execution with input pre-processing and output post-processing, simplifying deployment and adding functionality like multi-stream, bucketing, and dynamic shape.
 
 ## Use Case Examples
 
@@ -35,4 +35,4 @@ The examples below walk through use cases leveraging DeepSparse for testing and 
 ## Other Use Cases
 
 More documentation, models, use cases, and examples are continually being added.
-If you don't see one you're interested in, search the [DeepSparse Github repo](https://github.com/neuralmagic/deepsparse), the [SparseML Github repo](https://github.com/neuralmagic/sparseml), the [SparseZoo website](https://sparsezoo.neuralmagic.com/), or ask in the [Neural Magic Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ).
+If you don't see one you're interested in, search the [DeepSparse Github repo](https://github.com/neuralmagic/deepsparse), [SparseML Github repo](https://github.com/neuralmagic/sparseml), or [SparseZoo website](https://sparsezoo.neuralmagic.com/). Or, ask in the [Neural Magic Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ).

--- a/src/content/get-started/try-a-model/custom-use-case.mdx
+++ b/src/content/get-started/try-a-model/custom-use-case.mdx
@@ -9,19 +9,19 @@ index: 3000
 
 This page explains how to run a model on the DeepSparse Engine for a custom task inside a Python API called `Pipelines.`
 
-`Pipelines` wrap key utilities around the DeepSparse Engine for easy testing and deployment.
+`Pipelines` wraps key utilities around the DeepSparse Engine for easy testing and deployment.
 
 The DeepSparse Engine supports many operators within ONNX, enabling performance for most models and use cases outside of the ones available on the SparseZoo.
-The `CustomTaskPipeline` enables you to wrap your model with custom pre and post-processing functions for simple deployment and benchmarking.
+The `CustomTaskPipeline` enables you to wrap your model with custom pre-processing and post-processing functions for simple deployment and benchmarking.
 In this way, the simplicity of `Pipelines` is combined with the performance of DeepSparse for arbitrary use cases.
 
-## Install Requirements
+## Installation Requirements
 
-This example requires [DeepSparse General Install](/get-started/install/deepsparse) and [SparseML Torchvision Install](/get-started/install/sparseml).
+This example requires [DeepSparse General Installation](/get-started/install/deepsparse) and [SparseML Torchvision Installation](/get-started/install/sparseml).
 
 ## Model Setup
 
-For custom model deployment, first export your model to the ONNX model format (create a `model.onnx` file).
+For custom model deployment, export your model to the ONNX model format (create a `model.onnx` file).
 SparseML has available wrappers for ONNX export classes and APIs for a more straightforward export process.
 A sample export utilizing this API for a MobileNetV2 TorchVision model is given below.
 
@@ -41,7 +41,7 @@ Examples for both are given below.
 
 ## Inference Pipelines
 
-The `model.onnx` file can be passed into a DeepSparse `CustomTaskPipeline` utilizing the `model_path` argument alongside optional pre and post-processing functions.
+The `model.onnx` file can be passed into a DeepSparse `CustomTaskPipeline` utilizing the `model_path` argument alongside optional pre-processing and post-processing functions.
 
 A sample image is downloaded that will be run through the example to test the `Pipeline`.
 
@@ -49,7 +49,7 @@ A sample image is downloaded that will be run through the example to test the `P
 wget -O basilica.jpg https://raw.githubusercontent.com/neuralmagic/deepsparse/main/src/deepsparse/yolo/sample_images/basilica.jpg
 ```
 
-Next, the pre and post-processing functions are defined, and the pipeline enabling the classification of the image file is instantiated:
+Next, the pre-processing and post-processing functions are defined, and the pipeline enabling the classification of the image file is instantiated:
 
 ```python
 from deepsparse.pipelines.custom_pipeline import CustomTaskPipeline
@@ -90,7 +90,7 @@ print(inference)
 
 ## Benchmarking
 
-The DeepSparse install includes a benchmark CLI for convenient and easy inference performance benchmarking: `deepsparse.benchmark`.
+The DeepSparse installation includes a benchmark CLI for convenient and easy inference performance benchmarking: `deepsparse.benchmark`.
 The CLI takes in both SparseZoo stubs or paths to a local `model.onnx` file.
 
 The code below provides an example for benchmarking the previously exported MobileNetV2 model.

--- a/src/content/get-started/try-a-model/cv-object-detection.mdx
+++ b/src/content/get-started/try-a-model/cv-object-detection.mdx
@@ -9,33 +9,33 @@ index: 2000
 
 This page explains how to run a trained model on the DeepSparse Engine for Object Detection inside a Python API called `Pipelines.`
 
-`Pipelines` wrap key utilities around the DeepSparse Engine for easy testing and deployment.
+`Pipelines` wraps key utilities around the DeepSparse Engine for easy testing and deployment.
 
-The object detection `Pipeline`, for example, wraps a trained model with the proper preprocessing and postprocessing pipelines such as NMS.
+The object detection `Pipeline`, for example, wraps a trained model with the proper pre-processing and post-processing pipelines such as NMS.
 This enables the passing of raw images and receiving the bounding boxes from the DeepSparse Engine without any extra effort.
 With all of this built on top of the DeepSparse Engine, the simplicity of `Pipelines` is combined with GPU-class performance on CPUs for sparse models.
 
 ## Install Requirements
 
-This example requires [DeepSparse YOLO Install](/get-started/install/deepsparse).
+This example requires [DeepSparse YOLO Installation](/get-started/install/deepsparse).
 
 ## Model Setup
 
 The object detection `Pipeline` uses Ultralytics YOLOv5 standards and configurations for model setup.
-The possible files/variables that can be passed in are the following:
-- `model.onnx` - The exported YOLOv5 model in the ONNX format.
-- `model.yaml` - The Ultralytics model config file containing configuration information about the model and its post-processing.
+The possible files/variables that can be passed in are:
+- `model.onnx` - Exported YOLOv5 model in the ONNX format.
+- `model.yaml` - Ultralytics model configuration file containing configuration information about the model and its post-processing.
 - `class_names` - A list, dictionary, or file containing the index to class name mappings for the trained model.
 
 `model.onnx` is the only required file.
-The pipeline will default to a standard setup for the COCO dataset if the model config file or class names are not provided.
+The pipeline will default to a standard setup for the COCO dataset if the model configuration file or class names are not provided.
 
 There are two options for passing these files to DeepSparse:
 
 <details>
-<summary><b>1) Using The SparseZoo</b></summary>
+<summary><b>1) Using the SparseZoo</b></summary>
 
-This pathway is relevant if you want to use a pre-sparsified state-of-the-art model off the shelpf.
+This pathway is relevant if you want to use a pre-sparsified state-of-the-art model off the shelf.
 
 SparseZoo is a repository of pre-trained and pre-sparsified models. DeepSparse supports SparseZoo stubs as inputs for automatic download and inclusion into easy testing and deployment.
 These models include dense and sparsified versions of YOLOv5 trained on the COCO dataset for performant and general detection, among others.
@@ -54,12 +54,12 @@ These SparseZoo stubs can be passed as arguments to the `Pipeline` constructor i
 </details>
 
 <details>
-<summary><b>2) Using a Custom Local Model</b></summary>
+<summary><b>2) Using a custom local model</b></summary>
 
 This pathway is relevant if you want to use a model fine-tuned on your data with SparseML or a custom model.
 
 There are three steps to using a local model with `Pipelines`:
-1. Create the `model.onnx` file (if you trained with SparseML, use the [ONNX export script](https://github.com/neuralmagic/sparseml/tree/main/integrations/ultralytics-yolov5#exporting-the-sparse-model-to-onnx))
+1. Create the `model.onnx` file (if you trained with SparseML, use the [ONNX export script](https://github.com/neuralmagic/sparseml/tree/main/integrations/ultralytics-yolov5#exporting-the-sparse-model-to-onnx)).
 2. Collect the `model.yaml` file and `class_names` listed above.
 3. Pass the local paths of the files in place of the SparseZoo stubs.
 
@@ -69,9 +69,9 @@ The examples below use the SparseZoo stubs. Pass the path to the local model in 
 
 ## Inference Pipelines
 
-With the object detection model setup, it can then be passed into a DeepSparse `Pipeline` utilizing the `model_path` argument.
+With the object detection model set up, the model can be passed into a DeepSparse `Pipeline` utilizing the `model_path` argument.
 The SparseZoo stub for the sparse-quantized YOLOv5l model given at the beginning is used in the sample code below.
-It will automatically download the necessary files for the model from the SparseZoo and then compile them on your local machine in the DeepSparse engine.
+It will automatically download the necessary files for the model from the SparseZoo and then compile them on your local machine in the DeepSparse Engine.
 Once compiled, the model `Pipeline` is ready for inference with images.
 
 First, a sample image is downloaded that will be run through the example to test the pipeline.
@@ -80,7 +80,7 @@ First, a sample image is downloaded that will be run through the example to test
 wget -O basilica.jpg https://raw.githubusercontent.com/neuralmagic/deepsparse/main/src/deepsparse/yolo/sample_images/basilica.jpg
 ```
 
-Next, instantiate the `Pipeline` and pass the image in using the images argument:
+Next, instantiate the `Pipeline` and pass in the image using the images argument:
 
 ```python
 from deepsparse import Pipeline
@@ -99,7 +99,7 @@ print(inference)
 
 ## Benchmarking
 
-The DeepSparse install includes a CLI for convenient performance benchmarking.
+The DeepSparse installation includes a CLI for convenient performance benchmarking.
 You can pass a SparseZoo stub or a local `model.onnx` file.
 
 ### Dense YOLOv5l

--- a/src/content/get-started/try-a-model/cv-object-detection.mdx
+++ b/src/content/get-started/try-a-model/cv-object-detection.mdx
@@ -15,7 +15,7 @@ The object detection `Pipeline`, for example, wraps a trained model with the pro
 This enables the passing of raw images and receiving the bounding boxes from the DeepSparse Engine without any extra effort.
 With all of this built on top of the DeepSparse Engine, the simplicity of `Pipelines` is combined with GPU-class performance on CPUs for sparse models.
 
-## Install Requirements
+## Installation Requirements
 
 This example requires [DeepSparse YOLO Installation](/get-started/install/deepsparse).
 

--- a/src/content/get-started/try-a-model/nlp-text-classification.mdx
+++ b/src/content/get-started/try-a-model/nlp-text-classification.mdx
@@ -73,7 +73,7 @@ Pass the path of the local directory in the `--model_path` in place of the Spars
 
 ## Inference Pipelines
 
-With the text classification model setup, it can then be passed into a DeepSparse `Pipeline` utilizing the `model_path` argument.
+With the text classification model set up, the model can be passed into a DeepSparse `Pipeline` utilizing the `model_path` argument.
 The SparseZoo stub for the sparse-quantized DistilBERT model given at the beginning is used in the sample code below.
 The `Pipeline` automatically downloads the necessary files for the model from the SparseZoo and compiles them on your local machine in the DeepSparse Engine.
 Once compiled, the model `Pipeline` is ready for inference with text sequences.

--- a/src/content/get-started/try-a-model/nlp-text-classification.mdx
+++ b/src/content/get-started/try-a-model/nlp-text-classification.mdx
@@ -119,7 +119,7 @@ print(inference)
 
 ## Benchmarking
 
-The DeepSparse install includes a benchmark CLI for convenient and easy inference benchmarking: `deepsparse.benchmark`.
+The DeepSparse installation includes a benchmark CLI for convenient and easy inference benchmarking: `deepsparse.benchmark`.
 The CLI takes in either a SparseZoo stub or a path to a local `model.onnx` file.
 
 ### Dense DistilBERT

--- a/src/content/get-started/try-a-model/nlp-text-classification.mdx
+++ b/src/content/get-started/try-a-model/nlp-text-classification.mdx
@@ -9,35 +9,35 @@ index: 1000
 
 This page explains how to run a trained model with the DeepSparse Engine for NLP inside a Python API called `Pipelines.`
 
-`Pipelines` wrap key utilities around the DeepSparse Engine for easy testing and deployment.
+`Pipelines` wraps key utilities around the DeepSparse Engine for easy testing and deployment.
 
-The text classification `Pipeline`, for example, wraps an NLP model with the proper preprocessing and postprocessing pipelines, such as tokenization.
+The text classification `Pipeline`, for example, wraps an NLP model with the proper pre-processing and post-processing pipelines, such as tokenization.
 This enables passing in raw text sequences and receiving the labeled predictions from the DeepSparse Engine without any extra effort.
 With all of this built on top of the DeepSparse Engine, the simplicity of `Pipelines` is combined with GPU-class performance on CPUs for sparse models.
 
-## Install Requirements
+## Installation Requirements
 
-This example requires [DeepSparse General Install](/get-started/install/deepsparse).
+This example requires [DeepSparse General Installation](/get-started/install/deepsparse).
 
 ## Model Setup
 
 The first step is collecting an ONNX representaiton of the model and required configuration files.
-The text classification `Pipeline` is integrated with HuggingFace and uses HuggingFace's standards
+The text classification `Pipeline` is integrated with Hugging Face and uses Hugging Face's standards
 and configurations for model setup. The following files are required:
-- `model.onnx` - The exported Transformers model in the ONNX format.
-- `tokenizer.json` - The HuggingFace tokenizer used with the model.
-- `tokenizer_config.json` - The HuggingFace tokenizer configuration used with the model.
-- `config.json` - The HuggingFace configuration file used with the model.
+- `model.onnx` - Exported Transformers model in the ONNX format.
+- `tokenizer.json` - Hugging Face tokenizer used with the model.
+- `tokenizer_config.json` - Hugging Face tokenizer configuration used with the model.
+- `config.json` - Hugging Face configuration file used with the model.
 
-For an example of the config files, checkout [BERT's model page on HuggingFace](https://huggingface.co/bert-base-uncased/tree/main).
+For an example of the configuration files, check out [BERT's model page on Hugging Face](https://huggingface.co/bert-base-uncased/tree/main).
 
 There are two options for passing these files to DeepSparse:
 
 <details>
 
-<summary><b>1) Using SparseZoo Stubs (Reccomended Starting Point)</b></summary>
+  <summary><b>1) Using SparseZoo stubs (reccomended starting point)</b></summary>
 
-SparseZoo contains several pre-sparsified Transformer models, including the config files listed above. DeepSparse is integrated
+SparseZoo contains several pre-sparsified Transformer models, including the configuration files listed above. DeepSparse is integrated
 with SparseZoo, and supports SparseZoo stubs as inputs for automatic download and inclusion into easy testing and deployment.
 
 The SparseZoo stubs can be found on SparseZoo model pages, and DistilBERT examples are provided below:
@@ -57,17 +57,17 @@ These SparseZoo stubs are passed arguments to the `Pipeline` constructor in the 
 
 <details>
 
-<summary><b>2) Using a Local Model</b></summary>
+<summary><b>2) Using a local model</b></summary>
 
 Alternatively, you can use a custom or fine-tuned model from your local drive.
 
 There are three steps to using a local model with `Pipelines`:
 
-1. Export model to `model.onnx` (if you trained with SparseML, use [ONNX export](https://github.com/neuralmagic/sparseml/tree/main/integrations/huggingface-transformers#exporting-to-onnx))
-2. Collect the configuration files listed above. These are generally stored with the resulting model files from HuggingFace training pipelines (as is the case with SparseML)
-3. Place the files into a directory
+1. Export the model to `model.onnx` (if you trained with SparseML, use [ONNX export](https://github.com/neuralmagic/sparseml/tree/main/integrations/huggingface-transformers#exporting-to-onnx)).
+2. Collect the configuration files listed above. These are generally stored with the resulting model files from Hugging Face training pipelines (as is the case with SparseML).
+3. Place the files into a directory.
 
-Pass the path the local directory in the `--model_path` in place of the SparseZoo stubs in the examples below.
+Pass the path of the local directory in the `--model_path` in place of the SparseZoo stubs in the examples below.
 
 </details>
 
@@ -75,7 +75,7 @@ Pass the path the local directory in the `--model_path` in place of the SparseZo
 
 With the text classification model setup, it can then be passed into a DeepSparse `Pipeline` utilizing the `model_path` argument.
 The SparseZoo stub for the sparse-quantized DistilBERT model given at the beginning is used in the sample code below.
-The `Pipeline` automatically downloads the necessary files for the model from the SparseZoo and compiles them on your local machine in the DeepSparse engine.
+The `Pipeline` automatically downloads the necessary files for the model from the SparseZoo and compiles them on your local machine in the DeepSparse Engine.
 Once compiled, the model `Pipeline` is ready for inference with text sequences.
 
 ```python

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -9,18 +9,18 @@ index: 0
 
 Neural Magic's Deep Sparse Platform provides models and tools needed to create sparse models and a CPU-based inference engine that runs sparse models at GPU speeds.
 
-Using the Deep Sparse Platform, you are free to deploy your neural networks anywhere you have a CPU from edge to cloud.
+Using the Deep Sparse Platform, you are free to deploy your neural networks from edge to cloud&mdash;anywhere you have a CPU.
 
-There are three products which accomplish these goals:
+Three products accomplish these goals:
 
 - [DeepSparse Engine](/products/deepsparse) offers best-in-class CPU performance for dense and sparsified models.
-Specifically for sparse models, it offers better than GPU performance in many use cases.
-The performance is achieved by leveraging technology around the unique cache hierarchy of CPUs for faster memory access, and sparsification techniques to reduce the number of FLOPs.
+Specifically for sparse models, it delivers better than GPU performance in many use cases.
+The performance is achieved by leveraging technology around the unique cache hierarchy of CPUs for faster memory access and sparsification techniques to reduce the number of FLOPs.
 
 - [SparseML](/products/sparseml) provides the tools to easily create sparse models via [sparse transfer-learning](/get-started/transfer-a-sparsified-model) from pre-sparsified models or state-of-the-art [sparsification algorithms](/user-guide/sparsification) that prune dense models from scratch.
-The algorithms are built on top of recipes that encode configurations and hyperparamers, enabling easy integration to common frameworks with only a few lines of code.
+The algorithms are built on recipes that encode configurations and hyperparamers, enabling easy integration with common frameworks with only a few lines of code.
 
-- [SparseZoo](/products/sparsezoo) stores dense and presparsified models/recipes ready for deployment, sparsification, and fine-tuning onto your data.
+- [SparseZoo](/products/sparsezoo) stores dense and pre-sparsified models/recipes ready for deployment, sparsification, and fine-tuning onto your data.
 SparseZoo stubs enable you to reference any model on the SparseZoo in a convenient and identifiable way.
 They are found throughout the documentation and the model pages on the [SparseZoo website](https://sparsezoo.neuralmagic.com).
 

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -17,6 +17,10 @@ Three products accomplish these goals:
 Specifically for sparse models, it delivers better than GPU performance in many use cases.
 The performance is achieved by leveraging technology around the unique cache hierarchy of CPUs for faster memory access and sparsification techniques to reduce the number of FLOPs.
 
+  The DeepSparse Engine is available in two editions:
+  - The [Community Edition](/products/deepsparse) is open-source and free for evaluation, research, and non-production use with our [Engine Community License](https://neuralmagic.com/legal/engine-license-agreement/).
+  - The [Enterprise Edition](/products/deepsparse-ent) requires a Trial License or [can be fully licensed](https://neuralmagic.com/legal/master-software-license-and-service-agreement/) for production, commercial applications.
+
 - [SparseML](/products/sparseml) provides the tools to easily create sparse models via [sparse transfer-learning](/get-started/transfer-a-sparsified-model) from pre-sparsified models or state-of-the-art [sparsification algorithms](/user-guide/sparsification) that prune dense models from scratch.
 The algorithms are built on recipes that encode configurations and hyperparamers, enabling easy integration with common frameworks with only a few lines of code.
 


### PR DESCRIPTION
Line 12: Please check. If "from edge to cloud" modifies "neural networks," I would make the suggested change. If "from edge to cloud" modifies "CPU," the sentence is fine as it was.

Line 18:  I'm assuming 100% of the audience will know what FLOPS means. If not, this should be spelled out with the acronym.