### PR TITLE
Update one-shot-llms-with-sparseml.mdx

### DIFF
--- a/versioned_docs/version-1.7.0/llms/guides/one-shot-llms-with-sparseml.mdx
+++ b/versioned_docs/version-1.7.0/llms/guides/one-shot-llms-with-sparseml.mdx
@@ -40,7 +40,11 @@ options:
 Example command:
 ```bash
 wget https://huggingface.co/nm-testing/TinyLlama-1.1B-Chat-v0.4-pruned50-quant/raw/main/recipe.yaml # download recipe
-sparseml.transformers.text_generation.oneshot --model_name TinyLlama/TinyLlama-1.1B-Chat-v1.0 --dataset_name open_platypus --recipe recipe.yaml --output_dir ./obcq_deployment --precision float16
+sparseml.transformers.text_generation.oneshot \
+ --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+ --dataset open_platypus --recipe recipe.yaml \
+ --output_dir ./obcq_deployment \
+ --precision float16
 ```
 ## How to Evaluate the One-shot Model
 Next, evaluate the model's performance using the [lm-evaluation-harness framework](https://github.com/neuralmagic/lm-evaluation-harness).


### PR DESCRIPTION
This fixes the one-shot command to replace `--model_name` with `--model` and `--dataset_name` with `--dataset`. It also adjusts the formatting of the command to use escaped newlines rather than a single long line.