### PR TITLE
Update hf-llm-to-deepsparse.mdx for 1.7.0

### DIFF
--- a/versioned_docs/version-1.7.0/llms/guides/hf-llm-to-deepsparse.mdx
+++ b/versioned_docs/version-1.7.0/llms/guides/hf-llm-to-deepsparse.mdx
@@ -85,8 +85,6 @@ These benchmarks used [models from SparseZoo](https://sparsezoo.neuralmagic.com/
 
 Benchmarking commands:
 ```bash
-export NM_BENCHMARK_KV_TOKENS=1
-
 # Decode benchmarking: Time to generate a token aka generated token/s
 deepsparse.benchmark --sequence_length 2048 --input_ids_length 1 --num_cores 8 zoo:llama2-7b-gsm8k_llama2_pretrain-base
 deepsparse.benchmark --sequence_length 2048 --input_ids_length 1 --num_cores 8 zoo:llama2-7b-gsm8k_llama2_pretrain-pruned50


### PR DESCRIPTION
Remove export NM_BENCHMARK_KV_TOKENS=1 for 1.7.0

To fix issue: https://app.asana.com/0/1206972022861411/1206972022861414/f